### PR TITLE
spec 파일 tsconfig exclude 추가

### DIFF
--- a/packages/animation/tsconfig.json
+++ b/packages/animation/tsconfig.json
@@ -12,5 +12,5 @@
     "allowSyntheticDefaultImports": true
   },
   "include": ["src"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "dist", "**/*.spec.*"]
 }

--- a/packages/utils/tsconfig.json
+++ b/packages/utils/tsconfig.json
@@ -13,5 +13,5 @@
     "allowSyntheticDefaultImports": true
   },
   "include": ["src"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "dist", "**/*.spec.*"]
 }


### PR DESCRIPTION
## 🔗 Related Issues

- #12

## ✨ Description

- utils 패키지의 tsconfig.json exclude에 spec 파일이 포함되지 않았던 문제 해결

<!-- Closes #12 -->
