### PR TITLE
packages/ui publishConfig 수정

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -68,6 +68,10 @@
     "main": "./dist/index.js",
     "types": "./dist/index.d.ts",
     "exports": {
+      ".": {
+        "import": "./dist/index.js",
+        "types": "./dist/index.d.ts"
+      },
       "./theme": {
         "import": "./dist/themes/theme.css.js",
         "types": "./dist/themes/theme.css.d.ts"


### PR DESCRIPTION
## 🔗 Related Issues

- #21

## ✨ Description

- publishConfig의 exports 필드가 잘못 설정되어 배포된 패키지를 사용할 수 없는 문제가 있었고, 수정하여 해결함.

<!-- Closes #21 -->
