### PR TITLE
GlobalStyle overscroll-behavior: auto로 수정

### DIFF
--- a/packages/ui/src/styles/globalStyle.css.ts
+++ b/packages/ui/src/styles/globalStyle.css.ts
@@ -5,7 +5,7 @@ import { darkThemeVars, lightThemeVars, theme } from '#themes';
 globalStyle('*', {
   boxSizing: 'border-box',
 
-  overscrollBehavior: 'none',
+  overscrollBehavior: 'auto',
   WebkitTapHighlightColor: 'transparent',
 });
 


### PR DESCRIPTION
## 🔗 Related Issues

- #42

## ✨ Description

최신 버전 크롬에서 이전에 정상 작동했던 스크롤이 작동하지 않는 문제가 발생.

이전에는 overflow: hidden 요소에 overscroll-behavior가 전파 안 됐으나 Chrome 144부터 전파되도록 변경되었음.
https://chromestatus.com/feature/5129635997941760

<!-- Closes #42 -->
