### PR TITLE
Dialog 컴포넌트 padding 수정

### DIFF
--- a/packages/ui/src/components/Dialog/Dialog.tsx
+++ b/packages/ui/src/components/Dialog/Dialog.tsx
@@ -19,6 +19,7 @@ export const Dialog = forwardRef<HTMLDivElement, DialogProps>(
         className={clsx(s.container, className, sx(propSx))}
         flexDirection="row"
         gap="lg"
+        padding="xl"
         flex
         {...props}
       >

--- a/packages/ui/src/components/Dialog/DialogContent.css.ts
+++ b/packages/ui/src/components/Dialog/DialogContent.css.ts
@@ -4,8 +4,6 @@ import { theme } from '#themes';
 import * as header from './DialogHeader.css';
 
 export const container = styleWithLayer({
-  padding: '0 1.5rem 1.5rem 1.5rem',
-
   wordBreak: 'break-all',
 
   selectors: {


### PR DESCRIPTION
## 🔗 Related Issues

- #47

## ✨ Description

- `Dialog` 컴포넌트의 padding이 잘못되어 `useDialog`로 호출한 `alert`, `confirm`의 레이아웃이 깨지는 문제 해결

<!-- Closes #47 -->
