### PR TITLE
`DialogHeader` padding 수정

### DIFF
--- a/packages/ui/src/components/Dialog/DialogHeader.css.ts
+++ b/packages/ui/src/components/Dialog/DialogHeader.css.ts
@@ -4,7 +4,7 @@ import { theme } from '#themes';
 export const container = styleWithLayer({
   position: 'sticky',
   top: '0',
-  padding: '1.5rem',
+  padding: '0.25rem',
   zIndex: '10',
 
   backgroundColor: `rgb(${theme.color.background})`,


### PR DESCRIPTION
## 🔗 Related Issues

- #54

## ✨ Description

- `DialogHeader` 컴포넌트의 padding이 지나치게 두꺼워서 대폭 줄임

<!-- Closes #54 -->
