### PR TITLE
`ts2742` 에러 해결

### DIFF
--- a/packages/react-search-params/src/index.ts
+++ b/packages/react-search-params/src/index.ts
@@ -3,3 +3,4 @@ export * from './createSearchParamsStore';
 export * from './parser';
 export * from './SearchParamsProvider';
 export * as Serializer from './serializers';
+export type * from './types';


### PR DESCRIPTION
## 🔗 Related Issues

- #62

## ✨ Description

- 특정 함수가 사용하는 타입이 번들 entry에 노출되지 않아서 발생한 에러였음.

<!-- Closes #62 -->
