### PR TITLE
partial schema `arrayParams` 타입 에러 해결

### DIFF
--- a/packages/react-search-params/src/createSearchParamsSchema.ts
+++ b/packages/react-search-params/src/createSearchParamsSchema.ts
@@ -6,11 +6,13 @@ interface BaseOption<T> {
   defaultValue: T;
   /** If a value type is an array, you must explicitly provide the keys of those params as an array. */
   arrayParams?: {
-    [K in keyof T]: T[K] extends unknown[] ? K : never;
+    [K in keyof T]: NonNullable<T[K]> extends unknown[] ? K : never;
   }[keyof T][];
   /** Function that validates the schema value. It must throw on failure. */
   validate: (params: {
-    [K in keyof T]?: T[K] extends unknown[] ? T[K] | string[] : T[K] | string;
+    [K in keyof T]?: NonNullable<T[K]> extends unknown[]
+      ? T[K] | string[]
+      : T[K] | string;
   }) => T;
   /**
    * Skips runtime validation for developer input because TypeScript compile-time type checking is sufficient.

--- a/packages/react-search-params/src/createSearchParamsStore.spec.ts
+++ b/packages/react-search-params/src/createSearchParamsStore.spec.ts
@@ -339,4 +339,49 @@ describe('createSearchParamsStore', () => {
 
     expect(window.location.search).toBe('?q=react');
   });
+
+  it('returns the expected value when using arrayParams in a partial schema whether the param exists or not', () => {
+    window.history.replaceState({}, '', '/?tags=1');
+    const store = createSearchParamsStore({ serializer: delimiter(',') });
+    cleanups.push(store.cleanup);
+
+    const partialArraySchema = createSearchParamsSchema<{
+      tags: number[];
+    }>({
+      partial: true,
+      defaultValue: {},
+      arrayParams: ['tags'],
+      validate: (params) => {
+        return {
+          tags: params.tags?.map(Number),
+        };
+      },
+    });
+
+    const { result } = renderHook(() =>
+      store.useParams(partialArraySchema, ['tags']),
+    );
+
+    expect(result.current[0]).toEqual({
+      tags: [1],
+    });
+
+    act(() => {
+      window.history.pushState({}, '', '/');
+      window.dispatchEvent(new PopStateEvent('popstate'));
+    });
+
+    expect(result.current[0]).toEqual({
+      tags: undefined,
+    });
+
+    act(() => {
+      window.history.pushState({}, '', '/?tags=1,2');
+      window.dispatchEvent(new PopStateEvent('popstate'));
+    });
+
+    expect(result.current[0]).toEqual({
+      tags: [1, 2],
+    });
+  });
 });


### PR DESCRIPTION
## 🔗 Related Issues

- #70

## ✨ Description

- `partial schema` `arrayParams` 타입 에러 해결
  - partial schema의 경우 배열 타입이 `unknown[] | undefined`이 되기에 배열 체크를 `NonNullable<T>`로 수정함.
- 해당 케이스 테스트 코드 추가

<!-- Closes #70 -->
