### PR TITLE
`pushState`/`replaceState` 시 상태 업데이트

### DIFF
--- a/packages/react-search-params/src/createSearchParamsStore.spec.ts
+++ b/packages/react-search-params/src/createSearchParamsStore.spec.ts
@@ -114,6 +114,44 @@ describe('createSearchParamsStore', () => {
     });
   });
 
+  it('updates store state when pushState is called', () => {
+    window.history.replaceState({}, '', '/?q=first&page=1');
+    const store = createSearchParamsStore({ serializer: delimiter(',') });
+    cleanups.push(store.cleanup);
+
+    const { result } = renderHook(() => store.useAllParams(schema));
+
+    act(() => {
+      window.history.pushState({}, '', '/?q=second&page=4&enabled=true');
+    });
+
+    expect(result.current[0]).toEqual({
+      q: 'second',
+      page: 4,
+      tags: [],
+      enabled: true,
+    });
+  });
+
+  it('updates store state when replaceState is called', () => {
+    window.history.replaceState({}, '', '/?q=first&page=1');
+    const store = createSearchParamsStore({ serializer: delimiter(',') });
+    cleanups.push(store.cleanup);
+
+    const { result } = renderHook(() => store.useAllParams(schema));
+
+    act(() => {
+      window.history.replaceState({}, '', '/?q=third&page=5&enabled=true');
+    });
+
+    expect(result.current[0]).toEqual({
+      q: 'third',
+      page: 5,
+      tags: [],
+      enabled: true,
+    });
+  });
+
   it('calls onValidationFailed and keeps previous state on validation failure', () => {
     window.history.replaceState({}, '', '/?q=safe&page=1');
     const store = createSearchParamsStore({ serializer: delimiter(',') });
@@ -164,7 +202,7 @@ describe('createSearchParamsStore', () => {
     expect(result.current[0]).toEqual(schema.defaultValue);
   });
 
-  it('validates only on init and popstate when skipValidation is true', () => {
+  it('validates on init and history updates when skipValidation is true', () => {
     window.history.replaceState({}, '', '/?page=2');
     const store = createSearchParamsStore({ serializer: delimiter(',') });
     cleanups.push(store.cleanup);
@@ -192,14 +230,16 @@ describe('createSearchParamsStore', () => {
     });
     expect(validate).toHaveBeenCalled();
 
+    const initialValidationCallCount = validate.mock.calls.length;
+
     act(() => {
       window.history.pushState({}, '', '/?page=3');
-      window.dispatchEvent(new PopStateEvent('popstate'));
     });
 
     expect(result.current[0]).toEqual({
       page: 3,
     });
+    expect(validate).toHaveBeenCalledTimes(initialValidationCallCount + 1);
 
     const validationCallCount = validate.mock.calls.length;
 
@@ -212,7 +252,7 @@ describe('createSearchParamsStore', () => {
     expect(result.current[0]).toEqual({
       page: 10,
     });
-    expect(validate).toHaveBeenCalledTimes(validationCallCount);
+    expect(validate).toHaveBeenCalledTimes(validationCallCount + 1);
   });
 
   it('passes single tag values to validate as an array', () => {
@@ -368,7 +408,7 @@ describe('createSearchParamsStore', () => {
 
     act(() => {
       window.history.pushState({}, '', '/');
-      window.dispatchEvent(new PopStateEvent('popstate'));
+      // window.dispatchEvent(new PopStateEvent('popstate'));
     });
 
     expect(result.current[0]).toEqual({
@@ -377,7 +417,7 @@ describe('createSearchParamsStore', () => {
 
     act(() => {
       window.history.pushState({}, '', '/?tags=1,2');
-      window.dispatchEvent(new PopStateEvent('popstate'));
+      // window.dispatchEvent(new PopStateEvent('popstate'));
     });
 
     expect(result.current[0]).toEqual({

--- a/packages/react-search-params/src/createSearchParamsStore.ts
+++ b/packages/react-search-params/src/createSearchParamsStore.ts
@@ -207,12 +207,33 @@ export const createSearchParamsStore = ({
     return [state, setState];
   };
 
+  const wrapHistoryMethods = (onChange: () => void) => {
+    const { history } = window;
+    const originalPushState = history.pushState;
+    const originalReplaceState = history.replaceState;
+
+    history.pushState = function (...args) {
+      originalPushState.apply(this, args);
+      onChange();
+    };
+
+    history.replaceState = function (...args) {
+      originalReplaceState.apply(this, args);
+      onChange();
+    };
+
+    return () => {
+      history.pushState = originalPushState;
+      history.replaceState = originalReplaceState;
+    };
+  };
+
   const init = () => {
     if (typeof window === 'undefined') {
       return () => {};
     }
 
-    const handlePopState = () => {
+    const handleSearchChange = () => {
       const nextState = serializer.deserialize(
         new URLSearchParams(window.location.search.replace(/^\?/, '')),
       );
@@ -221,12 +242,15 @@ export const createSearchParamsStore = ({
       store.setState(nextState);
     };
 
-    handlePopState();
+    handleSearchChange();
 
-    window.addEventListener('popstate', handlePopState);
+    const cleanupWrapHistoryMethods = wrapHistoryMethods(handleSearchChange);
+
+    window.addEventListener('popstate', handleSearchChange);
 
     return () => {
-      window.removeEventListener('popstate', handlePopState);
+      cleanupWrapHistoryMethods();
+      window.removeEventListener('popstate', handleSearchChange);
     };
   };
 


### PR DESCRIPTION
## 🔗 Related Issues

- #73

## ✨ Description

- `pushState`, `replaceState` 호출해도 상태 변화 감지하도록 수정
- navigation api는 baseline 2026 라서 도입 보류

<!-- Closes #73 -->
