### PR TITLE
next.js adapter 에러 해결

### DIFF
--- a/packages/react-search-params/src/adapters/next.tsx
+++ b/packages/react-search-params/src/adapters/next.tsx
@@ -7,17 +7,17 @@ import { SearchParamsProvider } from '../SearchParamsProvider';
 import type { AdapterProps } from './types';
 
 export const SearchParamsAdapter = ({ children, store }: AdapterProps) => {
-  const searchParams = useSearchParams().toString();
-  const cacheRef = useRef('');
+  const searchParams = useSearchParams()?.toString() ?? '';
+  const prevRef = useRef('');
 
-  const a = searchParams === '' ? searchParams : `?${searchParams}`,
-    b = typeof window !== 'undefined' ? window.location.search : '';
+  const next = searchParams === '' ? searchParams : `?${searchParams}`,
+    url = typeof window !== 'undefined' ? window.location.search : '';
 
   useEffect(() => {
-    if (a !== b) {
-      cacheRef.current = a;
+    if (next !== url) {
+      prevRef.current = next;
     }
-  }, [a, b]);
+  }, [next, url]);
 
   useEffect(() => {
     const handleSearchChange = () => {
@@ -32,7 +32,7 @@ export const SearchParamsAdapter = ({ children, store }: AdapterProps) => {
   }, [store]);
 
   return (
-    <SearchParamsProvider value={a === b ? cacheRef.current : a}>
+    <SearchParamsProvider value={next === url ? prevRef.current : next}>
       {children}
     </SearchParamsProvider>
   );


### PR DESCRIPTION
## 🔗 Related Issues

- #80

## ✨ Description

- Next.js 버전에 따라 useSearchParams()의 return type이 다른 문제가 있어서 next 15 환경에서 오류가 발생
- 테스트 코드는 추후 추가

<!-- Closes #80 -->
