### PR TITLE
`validateSearchParams` 구현 및 next adapter 버그 수정

### DIFF
--- a/packages/react-search-params/README.en.md
+++ b/packages/react-search-params/README.en.md
@@ -193,6 +193,52 @@ export default async function Page({
 
 In SSR, you can pass the initial search params through `InitialSearchParamsProvider`.
 
+## `validateSearchParams`
+
+Use this helper to validate object-based `searchParams` on the server.
+(This helper was implemented to validate `searchParams` on the server before passing them as SSR initial values.)
+
+```tsx
+import {
+  Serializer,
+  validateSearchParams,
+} from '@kimdw-rtk/react-search-params';
+
+export default async function Page({
+  searchParams,
+}: {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}) {
+  const params = validateSearchParams({
+    schema: searchParamsSchema,
+    serializer: Serializer.delimiter(','),
+    searchParams: await searchParams,
+  });
+
+  return <div>{params.page}</div>;
+}
+```
+
+### Options
+
+#### schema: `SearchParamsSchema<T>` `(required)`
+
+The schema used for validation. Internally, it calls `schema.validate`, and the return type follows the schema type.
+
+#### serializer: `Serializer` `(required)`
+
+The serializer used to interpret array params.
+It should match the `serializer` you use in `createSearchParamsStore` on the client.
+
+#### searchParams: `Record<string, string | string[] | undefined>` `(required)`
+
+The raw search params object received on the server.
+
+### Notes
+
+- Keys listed in `arrayParams` are normalized to arrays before they are passed to `validate`.
+- If `schema.validate` throws, `validateSearchParams` throws the same error.
+
 ## Caveats
 
 - If `URLSearchParams` is changed through the [History API](https://developer.mozilla.org/docs/Web/API/History_API) or a router API, `validation` will always run, so the runtime performance optimization path cannot be used. Use `useParams` when possible.

--- a/packages/react-search-params/README.md
+++ b/packages/react-search-params/README.md
@@ -193,6 +193,32 @@ export default async function Page({
 
 SSR에서는 `InitialSearchParamsProvider`를 사용해 초기 search params 값을 전달할 수 있습니다.
 
+## validateSearchParams
+
+서버에서 받은 객체 형태의 `searchParams`를 검증할 때 사용합니다.
+(SSR 초기값으로 전달할 `searchParams`를 서버에서 미리 검증하기 위해 구현되었습니다.)
+
+```tsx
+import {
+  Serializer,
+  validateSearchParams,
+} from '@kimdw-rtk/react-search-params';
+
+export default async function Page({
+  searchParams,
+}: {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}) {
+  const params = validateSearchParams({
+    schema: searchParamsSchema,
+    serializer: Serializer.delimiter(','),
+    searchParams: await searchParams,
+  });
+
+  return <div>{params.page}</div>;
+}
+```
+
 ## Caveats
 
 - [History API](https://developer.mozilla.org/docs/Web/API/History_API) / Router의 API를 통해 `URLSearchParams`를 변경하는 경우 `validation`이 항상 호출되어 런타임 성능 최적화 로직을 활용할 수 없습니다. 가능하면 `useParams` 훅을 사용하세요.

--- a/packages/react-search-params/package.json
+++ b/packages/react-search-params/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kimdw-rtk/react-search-params",
-  "version": "0.1.10",
+  "version": "0.2.0",
   "private": false,
   "main": "./src/index.ts",
   "type": "module",

--- a/packages/react-search-params/src/adapters/next.tsx
+++ b/packages/react-search-params/src/adapters/next.tsx
@@ -8,10 +8,11 @@ import type { AdapterProps } from './types';
 
 export const SearchParamsAdapter = ({ children, store }: AdapterProps) => {
   const searchParams = useSearchParams()?.toString() ?? '';
-  const prevRef = useRef('');
 
   const next = searchParams === '' ? searchParams : `?${searchParams}`,
     url = typeof window !== 'undefined' ? window.location.search : '';
+
+  const prevRef = useRef(url);
 
   useEffect(() => {
     if (next !== url) {

--- a/packages/react-search-params/src/createSearchParamsStore.ts
+++ b/packages/react-search-params/src/createSearchParamsStore.ts
@@ -254,40 +254,11 @@ export const createSearchParamsStore = ({
     store.setState(nextState);
   };
 
-  /**
-   * Validates object-based search params on the server side.
-   */
-  const validateParams = <T>(
-    schema: SearchParamsSchema<T>,
-    searchParams: Record<string, string | string[] | undefined>,
-  ) => {
-    const normalizedSearchParams = Object.fromEntries(
-      Object.entries(searchParams).map(([key, value]) => [
-        key,
-        Array.isArray(value) ? value.join(',') : value,
-      ]),
-    );
-    const params = serializer.deserialize(
-      new URLSearchParams(objectToURLSearchParams(normalizedSearchParams)),
-    );
-    const result = { ...params } as Record<keyof T, string | string[]>;
-
-    for (const key of schema.arrayParams as Set<keyof T>) {
-      const value = params[key as string];
-      if (value !== undefined && !Array.isArray(value)) {
-        result[key] = [value];
-      }
-    }
-
-    return schema.validate(result);
-  };
-
   return {
     useAllParams,
     useParams,
     useParamValueWithSelector: store.useStore,
     updateFromSearch,
-    validateParams,
   };
 };
 

--- a/packages/react-search-params/src/index.ts
+++ b/packages/react-search-params/src/index.ts
@@ -4,3 +4,4 @@ export * from './createSearchParamsStore';
 export * from './SearchParamsProvider';
 export * as Serializer from './serializers';
 export type * from './types';
+export * from './validateSearchParams';

--- a/packages/react-search-params/src/validateSearchParams.spec.ts
+++ b/packages/react-search-params/src/validateSearchParams.spec.ts
@@ -1,0 +1,91 @@
+import { createSearchParamsSchema } from './createSearchParamsSchema';
+import { delimiter } from './serializers/delimiter';
+import { repeated } from './serializers/repeated';
+import { validateSearchParams } from './validateSearchParams';
+
+describe('validateSearchParams', () => {
+  const schema = createSearchParamsSchema<{
+    query: string;
+    page: number;
+    tags: string[];
+  }>({
+    defaultValue: {
+      query: '',
+      page: 1,
+      tags: [],
+    },
+    arrayParams: ['tags'],
+    validate: (params) => ({
+      query: String(params.query ?? ''),
+      page: Number(params.page ?? 1),
+      tags: Array.isArray(params.tags)
+        ? params.tags.map(String)
+        : params.tags
+          ? [String(params.tags)]
+          : [],
+    }),
+  });
+
+  it('parses repeated serializer values correctly', () => {
+    expect(
+      validateSearchParams({
+        schema,
+        serializer: repeated(),
+        searchParams: {
+          query: 'react',
+          page: '2',
+          tags: ['ts', 'jest'],
+        },
+      }),
+    ).toEqual({
+      query: 'react',
+      page: 2,
+      tags: ['ts', 'jest'],
+    });
+  });
+
+  it('parses delimiter serializer values correctly', () => {
+    expect(
+      validateSearchParams({
+        schema,
+        serializer: delimiter(','),
+        searchParams: {
+          query: 'react',
+          page: '2',
+          tags: 'ts,jest',
+        },
+      }),
+    ).toEqual({
+      query: 'react',
+      page: 2,
+      tags: ['ts', 'jest'],
+    });
+  });
+
+  it('throws when validation fails', () => {
+    const invalidSchema = createSearchParamsSchema<{ page: number }>({
+      defaultValue: {
+        page: 1,
+      },
+      validate: (params) => {
+        const page = Number(params.page);
+
+        if (Number.isNaN(page)) {
+          throw new Error('Invalid page');
+        }
+
+        return { page };
+      },
+    });
+
+    expect(() =>
+      validateSearchParams({
+        schema: invalidSchema,
+        serializer: repeated(),
+        searchParams: {
+          page: 'abc',
+        },
+      }),
+    ).toThrow('Invalid page');
+  });
+});

--- a/packages/react-search-params/src/validateSearchParams.ts
+++ b/packages/react-search-params/src/validateSearchParams.ts
@@ -1,0 +1,33 @@
+import type { SearchParamsSchema } from '#createSearchParamsSchema';
+import type { Serializer } from '#types';
+import { objectToURLSearchParams } from '#utils';
+
+/**
+ * Validates object-based search params on the server side.
+ */
+export const validateSearchParams = <T>({
+  schema,
+  serializer,
+  searchParams,
+}: {
+  schema: SearchParamsSchema<T>;
+  serializer: Serializer;
+  searchParams: Record<string, string | string[] | undefined>;
+}) => {
+  const normalizedSearchParams = Object.fromEntries(
+    Object.entries(searchParams).map(([key, value]) => [key, value]),
+  );
+  const params = serializer.deserialize(
+    new URLSearchParams(objectToURLSearchParams(normalizedSearchParams)),
+  );
+  const result = { ...params } as Record<keyof T, string | string[]>;
+
+  for (const key of schema.arrayParams as Set<keyof T>) {
+    const value = params[key as string];
+    if (value !== undefined && !Array.isArray(value)) {
+      result[key] = [value];
+    }
+  }
+
+  return schema.validate(result);
+};


### PR DESCRIPTION
## 🔗 Related Issues

- #83

## ✨ Description

- `validateSearchParams` 구현 (store에 정의되어 있던 함수 분리)
- next.js adapter에서 CSR 초기 값을 가져오지 못하던 문제 해결 

<!-- Closes #83 -->
