### PR TITLE
UI 컴포넌트 개선

### DIFF
--- a/apps/storybook/src/stories/ScrollArea.stories.tsx
+++ b/apps/storybook/src/stories/ScrollArea.stories.tsx
@@ -16,6 +16,9 @@ const meta = {
       control: 'select',
       options: spacingOptions,
     },
+    showScrollbar: {
+      control: 'boolean',
+    },
     children: {
       control: false,
     },

--- a/packages/ui/src/components/LabelInteraction/index.tsx
+++ b/packages/ui/src/components/LabelInteraction/index.tsx
@@ -38,8 +38,6 @@ export const LabelInteraction = ({
   const targetRef = useCombinedRefs(child.props.ref, elementRef);
   const { ripple } = useRipple<HTMLElement>(elementRef);
 
-  console.log(child);
-
   return cloneElement(child, {
     ref: targetRef,
     className: clsx(

--- a/packages/ui/src/components/ScrollArea/ScrollArea.css.ts
+++ b/packages/ui/src/components/ScrollArea/ScrollArea.css.ts
@@ -1,8 +1,4 @@
-import { createVar } from '@vanilla-extract/css';
-
 import { styleWithComponents } from '#utils';
-
-export const paddingVar = createVar();
 
 export const scrollArea = styleWithComponents({
   overflowX: 'scroll',
@@ -16,20 +12,6 @@ export const scrollArea = styleWithComponents({
   },
 });
 
-export const mask = styleWithComponents({
-  maskImage: `linear-gradient(to right,
-
-  transparent 0%,
-
-  black ${paddingVar},
-
-  black calc(100% - ${paddingVar}),
-
-  transparent 100%)`,
-});
-
 export const wrapper = styleWithComponents({
   width: 'max-content',
-
-  paddingInline: paddingVar,
 });

--- a/packages/ui/src/components/ScrollArea/ScrollArea.css.ts
+++ b/packages/ui/src/components/ScrollArea/ScrollArea.css.ts
@@ -1,17 +1,61 @@
-import { styleWithComponents } from '#utils';
+import { sprinklesVars } from '#styles';
+import { theme } from '#themes';
+import { recipeWithComponents, styleWithComponents } from '#utils';
 
-export const scrollArea = styleWithComponents({
-  overflowX: 'scroll',
+export const scrollArea = recipeWithComponents({
+  base: {
+    overflowX: 'scroll',
 
-  width: '100%',
+    width: '100%',
 
-  userSelect: 'none',
-
-  '::-webkit-scrollbar': {
-    display: 'none',
+    userSelect: 'none',
   },
+
+  variants: {
+    showScrollbar: {
+      true: {
+        paddingBottom: '0.25rem',
+
+        '::-webkit-scrollbar': {
+          height: '0.25rem',
+          width: '0.25rem',
+        },
+        '::-webkit-scrollbar-button': {
+          height: sprinklesVars.spacing,
+          width: sprinklesVars.spacing,
+        },
+        '::-webkit-scrollbar-thumb': {
+          borderRadius: '0.5rem',
+
+          backgroundColor: `rgb(${theme.color['border']})`,
+        },
+        '::-webkit-scrollbar-track': {
+          backgroundColor: 'transparent',
+        },
+      },
+      false: {
+        '::-webkit-scrollbar': {
+          display: 'none',
+        },
+      },
+    },
+  },
+});
+
+export const mask = styleWithComponents({
+  maskImage: `linear-gradient(to right,
+
+  transparent 0%,
+
+  black ${sprinklesVars.spacing},
+
+  black calc(100% - ${sprinklesVars.spacing}),
+
+  transparent 100%)`,
 });
 
 export const wrapper = styleWithComponents({
   width: 'max-content',
+
+  paddingInline: sprinklesVars.spacing,
 });

--- a/packages/ui/src/components/ScrollArea/ScrollArea.tsx
+++ b/packages/ui/src/components/ScrollArea/ScrollArea.tsx
@@ -3,25 +3,20 @@
 import { forwardRef, useEffect, useRef } from 'react';
 
 import { useCombinedRefs } from '@kimdw-rtk/utils';
-import { assignInlineVars } from '@vanilla-extract/dynamic';
 import clsx from 'clsx';
 
 import { useMouseScroll } from '#hooks/useMouseScroll';
-import { sx } from '#styles';
-import { spacing } from '#tokens';
+import { sprinkles, sx, type SprinklesProps } from '#styles';
 import type { UIComponent } from '#types';
 
 import * as s from './ScrollArea.css';
 
 interface ScrollAreaProps extends UIComponent<'div'> {
-  innerPadding?: keyof typeof spacing;
+  innerPadding?: SprinklesProps['paddingX'];
 }
 
 export const ScrollArea = forwardRef<HTMLDivElement, ScrollAreaProps>(
-  (
-    { children, className, innerPadding = 'lg', sx: propSx, style, ...props },
-    ref,
-  ) => {
+  ({ children, className, innerPadding = 'lg', sx: propSx, ...props }, ref) => {
     const scrollAreaRef = useRef<HTMLDivElement>(null);
     const targetRef = useCombinedRefs(ref, scrollAreaRef);
     useMouseScroll(scrollAreaRef);
@@ -55,14 +50,12 @@ export const ScrollArea = forwardRef<HTMLDivElement, ScrollAreaProps>(
     return (
       <div
         ref={targetRef}
-        className={clsx(s.scrollArea, className, sx(propSx), s.mask)}
+        className={clsx(s.scrollArea, className, sx(propSx))}
         {...props}
-        style={{
-          ...style,
-          ...assignInlineVars({ [s.paddingVar]: spacing[innerPadding] }),
-        }}
       >
-        <div className={s.wrapper}>{children}</div>
+        <div className={clsx(s.wrapper, sprinkles({ paddingX: innerPadding }))}>
+          {children}
+        </div>
       </div>
     );
   },

--- a/packages/ui/src/components/ScrollArea/ScrollArea.tsx
+++ b/packages/ui/src/components/ScrollArea/ScrollArea.tsx
@@ -6,17 +6,28 @@ import { useCombinedRefs } from '@kimdw-rtk/utils';
 import clsx from 'clsx';
 
 import { useMouseScroll } from '#hooks/useMouseScroll';
-import { sprinkles, sx, type SprinklesProps } from '#styles';
+import { sprinkles, sx, type VarsSprinklesProps } from '#styles';
 import type { UIComponent } from '#types';
 
+import { varsSprinkles } from '../../styles/varsSprinkles';
 import * as s from './ScrollArea.css';
 
-interface ScrollAreaProps extends UIComponent<'div'> {
-  innerPadding?: SprinklesProps['paddingX'];
+interface ScrollAreaProps extends UIComponent<'div', typeof s.scrollArea> {
+  innerPadding?: VarsSprinklesProps['spacing'];
 }
 
 export const ScrollArea = forwardRef<HTMLDivElement, ScrollAreaProps>(
-  ({ children, className, innerPadding = 'lg', sx: propSx, ...props }, ref) => {
+  (
+    {
+      children,
+      className,
+      innerPadding,
+      showScrollbar = true,
+      sx: propSx,
+      ...props
+    },
+    ref,
+  ) => {
     const scrollAreaRef = useRef<HTMLDivElement>(null);
     const targetRef = useCombinedRefs(ref, scrollAreaRef);
     useMouseScroll(scrollAreaRef);
@@ -50,16 +61,21 @@ export const ScrollArea = forwardRef<HTMLDivElement, ScrollAreaProps>(
     return (
       <div
         ref={targetRef}
-        className={clsx(s.scrollArea, className, sx(propSx))}
+        className={clsx(
+          s.scrollArea({ showScrollbar }),
+          s.mask,
+          className,
+          sx(propSx),
+          varsSprinkles({ spacing: innerPadding }),
+        )}
         {...props}
       >
-        <div className={clsx(s.wrapper, sprinkles({ paddingX: innerPadding }))}>
-          {children}
-        </div>
+        <div className={s.wrapper}>{children}</div>
       </div>
     );
   },
 );
+
 ScrollArea.displayName = 'ScrollArea';
 
 export { s as scrollAreaCss };

--- a/packages/ui/src/components/ScrollArea/ScrollArea.tsx
+++ b/packages/ui/src/components/ScrollArea/ScrollArea.tsx
@@ -6,7 +6,7 @@ import { useCombinedRefs } from '@kimdw-rtk/utils';
 import clsx from 'clsx';
 
 import { useMouseScroll } from '#hooks/useMouseScroll';
-import { sprinkles, sx, type VarsSprinklesProps } from '#styles';
+import { sx, type VarsSprinklesProps } from '#styles';
 import type { UIComponent } from '#types';
 
 import { varsSprinkles } from '../../styles/varsSprinkles';
@@ -22,7 +22,7 @@ export const ScrollArea = forwardRef<HTMLDivElement, ScrollAreaProps>(
       children,
       className,
       innerPadding,
-      showScrollbar = true,
+      showScrollbar = false,
       sx: propSx,
       ...props
     },

--- a/packages/ui/src/styles/conditions.ts
+++ b/packages/ui/src/styles/conditions.ts
@@ -1,0 +1,6 @@
+import { breakpoint } from '#tokens';
+
+export const conditions = {
+  mobile: {},
+  desktop: { '@media': `screen and (min-width: ${breakpoint.md})` },
+};

--- a/packages/ui/src/styles/index.ts
+++ b/packages/ui/src/styles/index.ts
@@ -1,3 +1,5 @@
+export * from './conditions';
 export * from './layers.css';
 export * from './sprinkles.css';
 export * from './sx';
+export * from './varsSprinkles.css';

--- a/packages/ui/src/styles/sprinkles.css.ts
+++ b/packages/ui/src/styles/sprinkles.css.ts
@@ -1,9 +1,9 @@
 import { createVar } from '@vanilla-extract/css';
 import { createSprinkles, defineProperties } from '@vanilla-extract/sprinkles';
 
-import { sprinklesLayer } from '#styles';
+import { conditions, sprinklesLayer } from '#styles';
 import { theme } from '#themes';
-import { breakpoint, lightColor, spacing, typography } from '#tokens';
+import { lightColor, spacing, typography } from '#tokens';
 
 type ColorName = keyof typeof lightColor;
 type ColorScale<C extends ColorName> = keyof (typeof lightColor)[C];
@@ -72,10 +72,7 @@ const size = {
 
 export const boxProperties = defineProperties({
   '@layer': sprinklesLayer,
-  conditions: {
-    mobile: {},
-    desktop: { '@media': 'screen and (min-width: 1024px)' },
-  },
+  conditions,
   defaultCondition: 'mobile',
   properties: {
     display: ['flex', 'block', 'none', 'inline', 'inline-block', 'inline-flex'],
@@ -137,10 +134,7 @@ export const boxProperties = defineProperties({
 
 export const typographyProperties = defineProperties({
   '@layer': sprinklesLayer,
-  conditions: {
-    mobile: {},
-    desktop: { '@media': `screen and (min-width: ${breakpoint.md})` },
-  },
+  conditions,
   defaultCondition: 'mobile',
   properties: {
     lineHeight: typography.lineHeight,

--- a/packages/ui/src/styles/varsSprinkles.css.ts
+++ b/packages/ui/src/styles/varsSprinkles.css.ts
@@ -1,0 +1,67 @@
+import { createVar, style, type StyleRule } from '@vanilla-extract/css';
+
+import { conditions } from '#styles';
+import { spacing } from '#tokens';
+
+const withCondition = (
+  condition: Record<string, string>,
+  rule: StyleRule,
+): StyleRule => {
+  const entries = Object.entries(condition);
+
+  if (entries.length === 0) {
+    return rule;
+  }
+
+  const [atRule, query] = entries[0] as [string, string];
+
+  return {
+    [atRule]: {
+      [query]: rule,
+    },
+  } as StyleRule;
+};
+
+const vars = {
+  spacing,
+};
+
+export const sprinklesVars = {
+  spacing: createVar(),
+};
+
+export type VarsSprinklesProps = Partial<{
+  [T in keyof typeof vars]: Partial<
+    | Record<keyof typeof conditions, keyof (typeof vars)[T]>
+    | keyof (typeof vars)[T]
+  >;
+}>;
+
+export const varsClasses = {} as {
+  [T in keyof typeof vars]: Record<
+    keyof typeof conditions,
+    Record<keyof (typeof vars)[T], string>
+  >;
+};
+
+Object.entries(conditions).forEach(([_name, condition]) => {
+  for (const _item in vars) {
+    const item = _item as keyof typeof vars,
+      name = _name as keyof typeof conditions;
+    const itemVar = sprinklesVars[item];
+
+    varsClasses[item] = { ...varsClasses[item], [name]: {} };
+
+    Object.entries(vars[item]).forEach(([_key, value]) => {
+      const key = _key as keyof (typeof vars)[typeof item];
+
+      varsClasses[item][name][key] = style({
+        ...withCondition(condition, {
+          vars: {
+            [itemVar]: value,
+          },
+        }),
+      });
+    });
+  }
+});

--- a/packages/ui/src/styles/varsSprinkles.ts
+++ b/packages/ui/src/styles/varsSprinkles.ts
@@ -1,0 +1,31 @@
+import { varsClasses, type VarsSprinklesProps } from '#styles';
+
+type VarName = keyof typeof varsClasses;
+type ConditionName = keyof (typeof varsClasses)[VarName];
+type VarValue = keyof (typeof varsClasses)[VarName][ConditionName];
+
+export const varsSprinkles = (props: VarsSprinklesProps) => {
+  const classNames: string[] = [];
+
+  for (const item of Object.keys(props) as VarName[]) {
+    const conditions = props[item];
+
+    if (conditions === undefined) {
+      continue;
+    }
+
+    if (typeof conditions === 'string') {
+      const value = props[item] as VarValue;
+      classNames.push(varsClasses[item]['mobile'][value]);
+      continue;
+    }
+
+    for (const condition of Object.keys(conditions) as ConditionName[]) {
+      const value = conditions[condition] as VarValue;
+
+      classNames.push(varsClasses[item][condition][value]);
+    }
+  }
+
+  return classNames.join(' ');
+};

--- a/packages/ui/src/tokens/semantic/width.ts
+++ b/packages/ui/src/tokens/semantic/width.ts
@@ -2,4 +2,6 @@ export const width = {
   sm: '768px',
   md: '1024px',
   lg: '1440px',
+  xl: '1920px',
+  '2xl': '2560px',
 } as const;


### PR DESCRIPTION
## 🔗 Related Issues

- #96

## ✨ Description

- `ScrollArea` 스크롤을 볼 수 있는 props 추가하기

- `ScrollArea` innerPadding 값 반응형 가능하도록 수정하기
이를 구현하기 위해 css vars를 sprinkles처럼 사용할 수 있는 `varsSprinkles` 함수를 구현함.

- `Container` size xl, 2xl 추가
`width` token에 xl(1920px), 2xl(2560px) 추가함.

<!-- Closes #96 -->
