### PR TITLE
`Tabs` indicator animation 버그 수정

### DIFF
--- a/packages/ui/src/components/Tabs/Tabs.tsx
+++ b/packages/ui/src/components/Tabs/Tabs.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { forwardRef, useReducer } from 'react';
+import { forwardRef, useCallback, useReducer } from 'react';
 
 import clsx from 'clsx';
 
@@ -25,12 +25,15 @@ export const Tabs = forwardRef<HTMLDivElement, TabsProps>(
       selectedElement: undefined,
     } satisfies TabsState);
 
-    const selectTab = (
-      value: TabsState['value'],
-      selectedElement: TabsState['selectedElement'],
-    ) => {
-      dispatch({ type: 'SELECT_TAB', value, selectedElement });
-    };
+    const selectTab = useCallback(
+      (
+        value: TabsState['value'],
+        selectedElement: TabsState['selectedElement'],
+      ) => {
+        dispatch({ type: 'SELECT_TAB', value, selectedElement });
+      },
+      [],
+    );
 
     return (
       <TabsContext.Provider

--- a/packages/ui/src/components/Tabs/TabsIndicator.css.ts
+++ b/packages/ui/src/components/Tabs/TabsIndicator.css.ts
@@ -13,7 +13,7 @@ export const indicator = styleWithComponents({
 
   backgroundColor: `rgb(${theme.color.primary})`,
 
-  transition: 'transform 0.25s ease',
+  transformOrigin: '0',
 
   selectors: {
     [`${isAnimated} &`]: {

--- a/packages/ui/src/components/Tabs/TabsList.tsx
+++ b/packages/ui/src/components/Tabs/TabsList.tsx
@@ -20,6 +20,7 @@ export const TabsList = forwardRef<HTMLDivElement, TabsListProps>(
   ({ children, className, sx: propSx, ...props }, ref) => {
     const tabsContext = useContext(TabsContext);
     const indicatorRef = useRef<HTMLDivElement>(null);
+    const prevSelectedRef = useRef<HTMLElement>(undefined);
     const tabsListRef = useCombinedRefs(ref);
 
     if (tabsContext === undefined) {
@@ -35,15 +36,30 @@ export const TabsList = forwardRef<HTMLDivElement, TabsListProps>(
         return;
       }
 
-      const animatedIndicator = () => {
+      if (prevSelectedRef.current === undefined) {
+        prevSelectedRef.current = element;
+        return;
+      }
+
+      const animateIndicator = () => {
         const left = element.offsetLeft,
           width = element.offsetWidth;
-        indicator.style.transformOrigin = '0';
+
+        if (indicator.style.transform === '') {
+          const prevLeft = prevSelectedRef.current?.offsetLeft ?? 0,
+            prevWidth = prevSelectedRef.current?.offsetWidth ?? baseWidth;
+
+          indicator.style.transition = 'none';
+          indicator.style.transform = `translateX(${prevLeft}px) scaleX(${prevWidth / baseWidth})`;
+          void indicator.offsetLeft;
+          indicator.style.transition = 'transform 0.25s ease';
+        }
+
         indicator.style.transform = `translateX(${left}px) scaleX(${width / baseWidth})`;
       };
 
       indicator.style.display = 'block';
-      animatedIndicator();
+      animateIndicator();
 
       const handleTransitionEnd = () => {
         indicator.style.display = 'none';
@@ -54,7 +70,7 @@ export const TabsList = forwardRef<HTMLDivElement, TabsListProps>(
       indicator.addEventListener('transitionend', handleTransitionEnd);
 
       return () => {
-        animatedIndicator();
+        prevSelectedRef.current = tabsContext.selectedElement;
         indicator.removeEventListener('transitionend', handleTransitionEnd);
       };
     }, [tabsContext.selectedElement, tabsListRef]);
@@ -68,7 +84,7 @@ export const TabsList = forwardRef<HTMLDivElement, TabsListProps>(
         {children}
         <TabsIndicator
           ref={indicatorRef}
-          style={{ display: 'none', width: `${baseWidth}px` }}
+          style={{ display: 'none', width: baseWidth }}
         />
       </div>
     );

--- a/packages/ui/src/components/Tabs/TabsTrigger.tsx
+++ b/packages/ui/src/components/Tabs/TabsTrigger.tsx
@@ -1,7 +1,13 @@
 'use client';
 
-import { forwardRef, useContext, type MouseEvent } from 'react';
+import {
+  forwardRef,
+  useContext,
+  useLayoutEffect,
+  type MouseEvent,
+} from 'react';
 
+import { useCombinedRefs } from '@kimdw-rtk/utils';
 import clsx from 'clsx';
 
 import { sx } from '#styles';
@@ -18,6 +24,7 @@ interface TabsTriggerProps extends UIComponent<'button'> {
 export const TabsTrigger = forwardRef<HTMLButtonElement, TabsTriggerProps>(
   ({ children, value, className, sx: propSx, onClick, ...props }, ref) => {
     const tabsContext = useContext(TabsContext);
+    const triggerRef = useCombinedRefs<HTMLButtonElement>(ref);
 
     if (tabsContext === undefined) {
       throw new Error('TabsTrigger must be used within a Tabs.');
@@ -26,17 +33,29 @@ export const TabsTrigger = forwardRef<HTMLButtonElement, TabsTriggerProps>(
     const isSelected = tabsContext.value === value;
 
     const handleClick = (event: MouseEvent<HTMLButtonElement>) => {
-      if (isSelected) {
+      const trigger = triggerRef.current;
+
+      if (isSelected || !trigger) {
         return;
       }
 
-      tabsContext.selectTab(value, event.currentTarget);
+      tabsContext.selectTab(value, trigger);
       onClick?.(event);
     };
 
+    useLayoutEffect(() => {
+      const trigger = triggerRef.current;
+
+      if (!isSelected || tabsContext.selectedElement || !trigger) {
+        return;
+      }
+
+      tabsContext.selectTab(value, trigger);
+    }, [value, isSelected, tabsContext, triggerRef]);
+
     return (
       <button
-        ref={ref}
+        ref={triggerRef}
         className={clsx(className, s.container({ isSelected }), sx(propSx))}
         {...props}
         onClick={handleClick}


### PR DESCRIPTION
## 🔗 Related Issues

- #98

## ✨ Description

- `Tabs` 컴포넌트의 초기 indicator animation이 `TabsTrigger`의 크기에서 시작하는 게 아니라, 100px으로 고정되어 시작하던 버그 수정

<!-- Closes #98 -->
